### PR TITLE
supplement will appear in the cga section even when zero

### DIFF
--- a/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EattestV3ServiceImpl.kt
+++ b/src/main/kotlin/org/taktik/freehealth/middleware/service/impl/EattestV3ServiceImpl.kt
@@ -764,7 +764,7 @@ class EattestV3ServiceImpl(private val stsService: STSService, private val keyDe
                            Math.round((it.doctorSupplement ?: 0.0) * 100)
                                .toInt()
                         }.let {
-                           if (it !== 0) ItemType().apply {
+                          ItemType().apply {
                                ids.add(IDKMEHR().apply {
                                    s = IDKMEHRschemes.ID_KMEHR; sv = "1.0"; value =
                                    (itemId++).toString()
@@ -784,7 +784,7 @@ class EattestV3ServiceImpl(private val stsService: STSService, private val keyDe
                                            }
                                    }
                                }
-                           } else null
+                           }
                         },
                         ItemType().apply {
                            ids.add(IDKMEHR().apply {


### PR DESCRIPTION
CIN financial transparency updates: 
If a functionality to block sending of supplement exists in your software : it must be desactivated for all your users 		
ITEM SUPPLEMENT becomes mandatory (CGA level) (amount > 0.00 or = 0.00)		
ITEM SUPPLEMENT (CGA level) amount = sum of the amount of the ITEM SUPPLEMENT from each CGD transaction		
ITEM SUPPLEMENT becomes mandatory (CGD level) (amount > 0.00 or = 0.00)		
ITEM SUPPLEMENT : amount must 0.00 if no supplements are requested by the physicians	